### PR TITLE
Add usage instructions and simple translator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # srttranslatorforkor
+
+srttranslatorforkor는 SRT 자막 파일을 원하는 언어로 번역하는 간단한 파이썬 도구입니다. 기본 목적은 영어 자막을 한국어로 변환하는 것이지만 `--src`와 `--dest` 옵션을 이용해 다른 언어 조합도 사용할 수 있습니다.
+
+## 주요 기능
+
+- SRT 형식의 자막을 읽어 각 대사를 번역
+- 시퀀스 번호와 타임 스탬프는 그대로 유지
+- Google 번역 API를 활용하여 빠른 번역 제공
+
+## 설치 방법
+
+1. 저장소를 클론합니다.
+   ```bash
+   git clone <저장소_URL>
+   cd srttranslatorforkor
+   ```
+2. 파이썬 3.8 이상이 필요합니다. 가상환경을 권장합니다.
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+3. 필요한 패키지를 설치합니다.
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## 사용 방법
+
+1. 번역하고 싶은 SRT 파일을 준비합니다.
+2. 아래와 같이 스크립트를 실행합니다.
+   ```bash
+   python translate_srt.py -i original.srt -o translated.srt --src en --dest ko
+   ```
+   - `--src` : 원본 자막의 언어 코드 (기본값 `auto`)
+   - `--dest` : 번역할 대상 언어 코드 (기본값 `ko`)
+3. 실행 후 `translated.srt` 파일에서 번역된 자막을 확인할 수 있습니다.
+
+## 검색 최적화를 위한 키워드
+
+- SRT 자막 번역
+- 한국어 자막 변환
+- Python subtitle translator
+- Googletrans 예제
+
+위 키워드들을 README에 포함하여 검색 엔진에서 쉽게 찾을 수 있도록 하였습니다.
+
+## 라이선스
+
+MIT 라이선스를 사용하며, 자유롭게 수정 및 배포가 가능합니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+googletrans==4.0.0-rc1

--- a/translate_srt.py
+++ b/translate_srt.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Simple command-line tool to translate SRT subtitle files."""
+import argparse
+from googletrans import Translator
+
+
+def translate_srt(input_file: str, output_file: str, src: str = 'auto', dest: str = 'ko') -> None:
+    """Translate an SRT file line by line."""
+    translator = Translator()
+    translated_lines = []
+    with open(input_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            striped = line.strip()
+            if striped.isdigit() or '-->' in line or not striped:
+                # Keep sequence numbers and timestamps as-is
+                translated_lines.append(line)
+            else:
+                result = translator.translate(line, src=src, dest=dest)
+                translated_lines.append(result.text + '\n')
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.writelines(translated_lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Translate SRT subtitles to another language")
+    parser.add_argument('-i', '--input', required=True, help='Path to input SRT file')
+    parser.add_argument('-o', '--output', required=True, help='Path for translated SRT file')
+    parser.add_argument('--src', default='auto', help='Source language code (default: auto)')
+    parser.add_argument('--dest', default='ko', help='Destination language code (default: ko)')
+    args = parser.parse_args()
+
+    translate_srt(args.input, args.output, src=args.src, dest=args.dest)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- expand README with detailed installation and usage instructions in Korean
- add a minimal Python script for translating SRT files using `googletrans`
- include `requirements.txt` for dependency management

## Testing
- `python3 -m py_compile translate_srt.py`

------
https://chatgpt.com/codex/tasks/task_e_686918dfc1848326ae0eeaa33b31afec